### PR TITLE
Fixes 'undefined' slug when navigating posts through categories

### DIFF
--- a/tests/dummy/app/templates/categories/category.hbs
+++ b/tests/dummy/app/templates/categories/category.hbs
@@ -6,7 +6,7 @@
 	<p>Posts categorized as <em>{{category.name}}</em>:</p>
 	<ul>
 		{{#each posts as |post|}}
-			<li>{{link-to post.title 'posts.post' post}}</li>
+			<li>{{link-to post.title 'posts.post' post.slug}}</li>
 		{{else}}
 			<li>There are no posts in this category. Yet.</li>
 		{{/each}}


### PR DESCRIPTION
In the category pages, post links had undefined slug.