### PR TITLE
Added support for case insensitive headers lookup

### DIFF
--- a/addon/adapters/wordpress.js
+++ b/addon/adapters/wordpress.js
@@ -1,5 +1,6 @@
 import DS from 'ember-data';
 import config from 'ember-get-config';
+import getHeader from '../utils/get-header';
 
 // The WP API requires a rest adapter.
 export default DS.RESTAdapter.extend({
@@ -12,8 +13,8 @@ export default DS.RESTAdapter.extend({
 		// Here we move it to a `meta` property which Ember expects.
 		if (payload) {
 			const meta = {
-				total: headers['X-WP-Total'],
-				totalPages: headers['X-WP-TotalPages']
+				total: getHeader(headers, 'X-WP-Total'),
+				totalPages: getHeader(headers, 'X-WP-TotalPages')
 			};
 			payload.meta = meta;
 		}

--- a/addon/utils/get-header.js
+++ b/addon/utils/get-header.js
@@ -1,0 +1,24 @@
+import Ember from 'ember';
+
+const { A, isNone } = Ember;
+
+/**
+ * Do a case-insensitive lookup of an HTTP header
+ *
+ * @function getHeader
+ * @private
+ * @param {Object} headers
+ * @param {string} name
+ * @return {string}
+ */
+export default function getHeader(headers, name) {
+  if (isNone(headers) || isNone(name)) {
+    return; // ask for nothing, get nothing.
+  }
+
+  const matchedKey = A(Object.keys(headers)).find((key) => {
+    return key.toLowerCase() === name.toLowerCase();
+  });
+
+  return headers[matchedKey];
+}

--- a/tests/unit/utils/get-header-test.js
+++ b/tests/unit/utils/get-header-test.js
@@ -1,0 +1,38 @@
+import { test } from 'ember-qunit';
+import getHeader from 'ember-ajax/utils/get-header';
+
+test('returns undefined when headers are undefined', function(assert) {
+  const header = getHeader(undefined);
+
+  assert.equal(header, undefined, 'undefined is returned');
+});
+
+test('returns undefined when name is undefined', function(assert) {
+  const header = getHeader({}, undefined);
+
+  assert.equal(header, undefined, 'undefined is returned');
+});
+
+test('matches result given by direct object access', function(assert) {
+  const headers = {
+    'wp-total-pages': '80',
+    'Wp-Total': '800',
+    'date': 'Fri, 12 Feb 2016 19:21:00 GMT'
+  };
+
+  assert.equal(getHeader(headers, 'wp-total-pages'), headers['wp-total-pages'], 'matches direct object access');
+  assert.equal(getHeader(headers, 'Wp-Total'), headers['Wp-Total'], 'matches direct object access');
+  assert.equal(getHeader(headers, 'date'), headers.date, 'matches direct object access');
+});
+
+test('performs case-insensitive lookup', function(assert) {
+  const headers = {
+    'wp-total-pages': '80',
+    'Wp-Total': '800',
+    'date': 'Fri, 12 Feb 2016 19:21:00 GMT'
+  };
+
+  assert.equal(getHeader(headers, 'wp-total-pAgEs'), headers['wp-total-pages'], 'matches case insensitive header');
+  assert.equal(getHeader(headers, 'wP-ToTAl'), headers['Wp-Total'], 'matches case insensitive header');
+  assert.equal(getHeader(headers, 'DATE'), headers.date, 'matches case insensitive header');
+});


### PR DESCRIPTION
This adds support for case insensitive headers lookup in accordance with the RFCs below;

[RFC 7230 (HTTP/1.1)](https://tools.ietf.org/html/rfc7230#section-3.2)

[RFC 7540 (HTTP/2)](https://tools.ietf.org/html/rfc7540#section-8.1.2)