### PR TITLE
Fix model exports

### DIFF
--- a/app/models/category.js
+++ b/app/models/category.js
@@ -1,1 +1,4 @@
-export { default } from 'ember-wordpress/models/term';
+import Term from 'ember-wordpress/models/term';
+
+export default Term.extend({
+});

--- a/app/models/page.js
+++ b/app/models/page.js
@@ -1,1 +1,4 @@
-export { default } from 'ember-wordpress/models/post';
+import Post from 'ember-wordpress/models/post';
+
+export default Post.extend({
+});

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -1,1 +1,4 @@
-export { default } from 'ember-wordpress/models/post';
+import Post from 'ember-wordpress/models/post';
+
+export default Post.extend({
+});

--- a/app/models/tag.js
+++ b/app/models/tag.js
@@ -1,1 +1,4 @@
-export { default } from 'ember-wordpress/models/term';
+import Term from 'ember-wordpress/models/term';
+
+export default Term.extend({
+});


### PR DESCRIPTION
Since `post` and `page` share the same `post` model, the models would some times not update.

Closes #42