### PR TITLE
The meta attribute is not in the root of the payload after normalizeArrayResponse

### DIFF
--- a/addon/serializers/wordpress.js
+++ b/addon/serializers/wordpress.js
@@ -17,8 +17,12 @@ export default DS.RESTSerializer.extend({
   normalizeArrayResponse(store, primaryModelClass, payload, id, requestType) {
     const payloadTemp = {};
     const rootKey = pluralize(primaryModelClass.modelName);
+    const meta = payload.meta;
+    
+    delete payload.meta;
 
     payloadTemp[rootKey] = payload;
+    payloadTemp.meta = meta;
 
     return this._super(store, primaryModelClass, payloadTemp, id, requestType);
   },


### PR DESCRIPTION
The `handleResponse` adds the meta into the payload, but in `normalizeArrayResponse` when the payload is moved under `rootKey` the meta isn't kept at the root.