### PR TITLE
more models and namespacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,7 @@
 module.exports = {
+  globals: {
+    server: true,
+  },
   root: true,
   parserOptions: {
     ecmaVersion: 2017,

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ testem.log
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+
+# JetBrain IDE files
+/.idea

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ var ENV = {
 
 ## Models
 
-You'll have four models ready out of the box: `post`, `page`, `category` and `tag`.
+You'll have seven models ready out of the box: `wordpress/post`, `wordpress/page`, `wordpress/category` `wordpress/tag`, `wordpress/attachment`,  `wordpress/comment`, `wordpress/user`.
 
-Note: the `post` and `page` models are identical and so are `category` and `tag`. For your own custom post types, it is recommended to extend the `post` model:
+Note: the `wordpress/post` and `wordpress/page` models are identical and so are `wordpress/category` and `wordpress/tag`. For your own custom post types, it is recommended to extend the `post` model:
 
 ```js
 // app/models/recipe.js

--- a/addon/adapters/wordpress.js
+++ b/addon/adapters/wordpress.js
@@ -19,5 +19,10 @@ export default DS.RESTAdapter.extend({
 			payload.meta = meta;
 		}
 		return this._super(status, headers, payload, requestData);
-	}
+	},
+
+  pathForType: function(modelName) {
+    modelName = modelName.replace('wordpress/', '');
+    return this._super(modelName);
+  }
 });

--- a/addon/models/attachment.js
+++ b/addon/models/attachment.js
@@ -1,0 +1,9 @@
+import DS from 'ember-data';
+import BaseModel from './base';
+
+export default BaseModel.extend({
+  title: DS.attr('rendered'),
+  media_details: DS.attr(),
+  source_url: DS.attr('string'),
+  caption: DS.attr('rendered')
+});

--- a/addon/models/base.js
+++ b/addon/models/base.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  acf: DS.attr(),
+  date: DS.attr('date'),
+  date_gmt: DS.attr('date'),
+});

--- a/addon/models/comment.js
+++ b/addon/models/comment.js
@@ -1,0 +1,26 @@
+import DS from 'ember-data';
+import { computed } from '@ember/object';
+import BaseModel from './base';
+
+export default BaseModel.extend({
+  author_avatar_urls: DS.attr(),
+  author_name: DS.attr('string'),
+  author_email: DS.attr('string'),
+  author_url: DS.attr('string'),
+  content: DS.attr('rendered'),
+  link: DS.attr('string'),
+  post: DS.belongsTo('wordpress/post'),
+  status: DS.attr('string'),
+
+  author_avatar_url_96: computed('author_avatar_urls', function () {
+    return this.get('author_avatar_urls.96');
+  }),
+
+  isHolding: computed('status', function() {
+    return this.get('status') === 'hold';
+  }),
+
+  isApproved: computed('status', function() {
+    return this.get('status') === 'approved';
+  })
+});

--- a/addon/models/post.js
+++ b/addon/models/post.js
@@ -1,16 +1,28 @@
 import DS from 'ember-data';
+import BaseModel from './base';
+import { computed } from '@ember/object';
+const { belongsTo, attr, hasMany } = DS;
 
-const {Model, attr, hasMany} = DS;
-
-export default Model.extend({
-	title: attr('string'),
-	content: attr('string'),
-	excerpt: attr('string'),
-	slug: attr('string'),
-	date: attr('date'),
-	featured_media: attr('number'),
-	format: attr(),
-	categories: hasMany('category', {async: true}),
-	tags: hasMany('tag', {async: true}),
-	acf: attr()
-});
+export default BaseModel.extend({
+  comment_status: attr('string'),
+  content: attr('rendered'),
+  excerpt: attr('rendered'),
+  link: attr('string'),
+  menu_order: attr('number'),
+  modified: attr('date'),
+  modified_gmt: attr('date'),
+  ping_status: attr('string'),
+  slug: attr('string'),
+  status: attr('string'),
+  template: attr('string'),
+  title: attr('rendered'),
+  author: belongsTo('wordpress/user'),
+  replies: hasMany('wordpress/comment'),
+  'wp:attachment': hasMany('wordpress/attachment'),
+  'wp:featuredmedia': belongsTo('wordpress/attachment'),
+  tags: hasMany('wordpress/tag'),
+  categories: hasMany('wordpress/category'),
+  commentsAreOpen: computed('comment_status', function(){
+    return this.get('comment_status') === 'open';
+  })
+})

--- a/addon/models/term.js
+++ b/addon/models/term.js
@@ -1,10 +1,9 @@
 // This is the base class used for the 'Category' and 'Tag' models
-
+import BaseModel from './base';
 import DS from 'ember-data';
+const { attr } = DS;
 
-const {Model, attr} = DS;
-
-export default Model.extend({
+export default BaseModel.extend({
 	count: attr('number'),
 	description: attr('string'),
 	link: attr('string'),

--- a/addon/models/user.js
+++ b/addon/models/user.js
@@ -1,0 +1,13 @@
+import BaseModel from './base';
+import DS from "ember-data";
+const { attr } = DS;
+import { alias } from '@ember/object/computed';
+
+export default BaseModel.extend({
+  name: attr('string'),
+  slug: attr('string'),
+  avatar_urls: attr(),
+  avatar_url_24: alias('avatar_urls.24'),
+  avatar_url_48: alias('avatar_urls.48'),
+  avatar_url_96: alias('avatar_urls.96')
+});

--- a/addon/serializers/wordpress.js
+++ b/addon/serializers/wordpress.js
@@ -24,7 +24,6 @@ export default DS.RESTSerializer.extend({
       hash.links[relationship] = hash['_links'][relationship][0].href;
     });
     delete hash['_links'];
-    console.log(this._super(modelClass, hash, prop));
     return this._super(modelClass, hash, prop);
   },
 

--- a/addon/serializers/wordpress.js
+++ b/addon/serializers/wordpress.js
@@ -2,50 +2,41 @@ import DS from 'ember-data';
 import {pluralize} from 'ember-inflector';
 
 export default DS.RESTSerializer.extend({
-  isNewSerializerAPI: true,
 
-  // Here we wrap the payload in a named object after the model type
-  // because this is what Ember expects { post: { datahere } }
   normalizeSingleResponse(store, primaryModelClass, payload, id, requestType) {
-    var payloadTemp = {};
-    payloadTemp[primaryModelClass.modelName] = [payload];
-
-    return this._super(store, primaryModelClass, payloadTemp, id, requestType);
+    let normalizedPayload = {};
+    normalizedPayload[primaryModelClass.modelName] = [payload];
+    return this._super(store, primaryModelClass, normalizedPayload, id, requestType);
   },
 
-  // Then, we can deal with our missing root element when extracting arrays from the JSON.
   normalizeArrayResponse(store, primaryModelClass, payload, id, requestType) {
-    const payloadTemp = {};
-    const rootKey = pluralize(primaryModelClass.modelName);
-    const meta = payload.meta;
-    
+    let normalizedPayload = {};
+    normalizedPayload.meta = payload.meta;
     delete payload.meta;
-
-    payloadTemp[rootKey] = payload;
-    payloadTemp.meta = meta;
-
-    return this._super(store, primaryModelClass, payloadTemp, id, requestType);
+    normalizedPayload[pluralize(primaryModelClass.modelName)] = payload;
+    return this._super(store, primaryModelClass, normalizedPayload, id, requestType);
   },
 
   normalize(modelClass, hash, prop) {
-    /* For fields like content, title and excerpt the Wordpress API returns a format like this:
-      title: {rendered: "my title"}
-      or for empty fields:
-      title: {rendered: ""}
-      ... this results in [object Object] in Ember templates.
-      Make sure to either return the `rendered` part or `null`.
-    */
-    function getRendered (prop) {
-      if (prop && prop.rendered) {
-        return prop.rendered;
-      }
-      return null;
-    }
-
-    hash.content = getRendered(hash.content)
-    hash.title = getRendered(hash.title)
-    hash.excerpt = getRendered(hash.excerpt)
-
+    if (!('_links' in hash)) return this._super(modelClass, hash, prop);
+    hash.links = {};
+    Object.keys(hash['_links']).forEach(relationship => {
+      hash.links[relationship] = hash['_links'][relationship][0].href;
+    });
+    delete hash['_links'];
+    console.log(this._super(modelClass, hash, prop));
     return this._super(modelClass, hash, prop);
+  },
+
+  serializeIntoHash(data, type, record, options) {
+    data = Object.assign(data, this.serialize(record, options));
+  },
+
+  extractMeta(store, typeClass, payload) {
+    if (payload && payload['meta'] !== undefined) {
+      let meta = payload.meta;
+      delete payload.meta;
+      return meta;
+    }
   }
 });

--- a/addon/transforms/rendered.js
+++ b/addon/transforms/rendered.js
@@ -1,0 +1,11 @@
+import DS from 'ember-data';
+
+export default DS.Transform.extend({
+  deserialize(serialized) {
+    return serialized.rendered;
+  },
+
+  serialize(deserialized) {
+    return deserialized;
+  }
+});

--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,1 +1,0 @@
-export {default} from 'ember-wordpress/adapters/wordpress';

--- a/app/adapters/wordpress/attachment.js
+++ b/app/adapters/wordpress/attachment.js
@@ -1,0 +1,3 @@
+import WordpressAdapter from 'ember-wordpress/adapters/wordpress';
+
+export default WordpressAdapter.extend({});

--- a/app/adapters/wordpress/category.js
+++ b/app/adapters/wordpress/category.js
@@ -1,0 +1,3 @@
+import WordpressAdapter from 'ember-wordpress/adapters/wordpress';
+
+export default WordpressAdapter.extend({});

--- a/app/adapters/wordpress/comment.js
+++ b/app/adapters/wordpress/comment.js
@@ -1,0 +1,3 @@
+import WordpressAdapter from 'ember-wordpress/adapters/wordpress';
+
+export default WordpressAdapter.extend({});

--- a/app/adapters/wordpress/page.js
+++ b/app/adapters/wordpress/page.js
@@ -1,0 +1,3 @@
+import WordpressAdapter from 'ember-wordpress/adapters/wordpress';
+
+export default WordpressAdapter.extend({});

--- a/app/adapters/wordpress/post.js
+++ b/app/adapters/wordpress/post.js
@@ -1,0 +1,3 @@
+import WordpressAdapter from 'ember-wordpress/adapters/wordpress';
+
+export default WordpressAdapter.extend({});

--- a/app/adapters/wordpress/tag.js
+++ b/app/adapters/wordpress/tag.js
@@ -1,0 +1,3 @@
+import WordpressAdapter from 'ember-wordpress/adapters/wordpress';
+
+export default WordpressAdapter.extend({});

--- a/app/adapters/wordpress/user.js
+++ b/app/adapters/wordpress/user.js
@@ -1,0 +1,3 @@
+import WordpressAdapter from 'ember-wordpress/adapters/wordpress';
+
+export default WordpressAdapter.extend({});

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -1,4 +1,0 @@
-import Post from 'ember-wordpress/models/post';
-
-export default Post.extend({
-});

--- a/app/models/wordpress/attachment.js
+++ b/app/models/wordpress/attachment.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-wordpress/models/attachment';

--- a/app/models/wordpress/category.js
+++ b/app/models/wordpress/category.js
@@ -1,4 +1,3 @@
 import Term from 'ember-wordpress/models/term';
 
-export default Term.extend({
-});
+export default Term.extend({});

--- a/app/models/wordpress/comment.js
+++ b/app/models/wordpress/comment.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-wordpress/models/comment';

--- a/app/models/wordpress/page.js
+++ b/app/models/wordpress/page.js
@@ -1,4 +1,3 @@
 import Post from 'ember-wordpress/models/post';
 
-export default Post.extend({
-});
+export default Post.extend({});

--- a/app/models/wordpress/post.js
+++ b/app/models/wordpress/post.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-wordpress/models/post';

--- a/app/models/wordpress/tag.js
+++ b/app/models/wordpress/tag.js
@@ -1,4 +1,3 @@
 import Term from 'ember-wordpress/models/term';
 
-export default Term.extend({
-});
+export default Term.extend({});

--- a/app/models/wordpress/user.js
+++ b/app/models/wordpress/user.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-wordpress/models/user';

--- a/app/serializers/application.js
+++ b/app/serializers/application.js
@@ -1,1 +1,0 @@
-export {default} from 'ember-wordpress/serializers/wordpress';

--- a/app/serializers/wordpress/attachment.js
+++ b/app/serializers/wordpress/attachment.js
@@ -1,0 +1,3 @@
+import WordpressSerializer from 'ember-wordpress/serializers/wordpress';
+
+export default WordpressSerializer.extend({});

--- a/app/serializers/wordpress/category.js
+++ b/app/serializers/wordpress/category.js
@@ -1,0 +1,3 @@
+import WordpressSerializer from 'ember-wordpress/serializers/wordpress';
+
+export default WordpressSerializer.extend({});

--- a/app/serializers/wordpress/comment.js
+++ b/app/serializers/wordpress/comment.js
@@ -1,0 +1,3 @@
+import WordpressSerializer from 'ember-wordpress/serializers/wordpress';
+
+export default WordpressSerializer.extend({});

--- a/app/serializers/wordpress/page.js
+++ b/app/serializers/wordpress/page.js
@@ -1,0 +1,3 @@
+import WordpressSerializer from 'ember-wordpress/serializers/wordpress';
+
+export default WordpressSerializer.extend({});

--- a/app/serializers/wordpress/post.js
+++ b/app/serializers/wordpress/post.js
@@ -1,0 +1,3 @@
+import WordpressSerializer from 'ember-wordpress/serializers/wordpress';
+
+export default WordpressSerializer.extend({});

--- a/app/serializers/wordpress/tag.js
+++ b/app/serializers/wordpress/tag.js
@@ -1,0 +1,3 @@
+import WordpressSerializer from 'ember-wordpress/serializers/wordpress';
+
+export default WordpressSerializer.extend({});

--- a/app/serializers/wordpress/user.js
+++ b/app/serializers/wordpress/user.js
@@ -1,0 +1,3 @@
+import WordpressSerializer from 'ember-wordpress/serializers/wordpress';
+
+export default WordpressSerializer.extend({});

--- a/app/transforms/rendered.js
+++ b/app/transforms/rendered.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-wordpress/transforms/rendered';

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-mirage": "^0.4.9",
     "ember-cli-qunit": "^4.1.1",
     "ember-cli-shims": "^1.2.0",
     "ember-cli-sri": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-wordpress",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "The bridge between Ember and Wordpress",
   "keywords": [
     "ember-addon",
@@ -8,7 +8,7 @@
     "wordpress"
   ],
   "license": "MIT",
-  "author": "Oskar Rough",
+  "author": "Oskar Rough, Oliver Görtz, Marc Diehlmann",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/tests/dummy/app/routes/categories.js
+++ b/tests/dummy/app/routes/categories.js
@@ -2,6 +2,6 @@ import Ember from 'ember';
 
 export default Ember.Route.extend({
 	model() {
-		return this.store.findAll('category');
+		return this.store.findAll('wordpress/category');
 	}
 });

--- a/tests/dummy/app/routes/categories/category.js
+++ b/tests/dummy/app/routes/categories/category.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Route.extend({
   model(params) {
     // How to query a category by slug.
-    return this.store.query('category', {
+    return this.store.query('wordpress/category', {
       slug: params.category_slug
     }).then(models => models.get('firstObject'));
   },

--- a/tests/dummy/app/routes/categories/category.js
+++ b/tests/dummy/app/routes/categories/category.js
@@ -10,7 +10,7 @@ export default Ember.Route.extend({
 
   setupController(controller, category) {
     // How to query all posts with a certain category.
-    const posts = this.store.query('post', {
+    const posts = this.store.query('wordpress/post', {
       categories: category.get('id')
     });
     controller.setProperties({

--- a/tests/dummy/app/routes/page.js
+++ b/tests/dummy/app/routes/page.js
@@ -3,7 +3,7 @@ import Ember from 'ember';
 export default Ember.Route.extend({
 	model(params) {
 		// Query a single page by slug/name
-		return this.store.query('page', {
+		return this.store.query('wordpress/page', {
 			slug: params.page_slug
 		}).then(models => models.get('firstObject'));
 	}

--- a/tests/dummy/app/routes/posts.js
+++ b/tests/dummy/app/routes/posts.js
@@ -6,6 +6,6 @@ export default Ember.Route.extend({
     // return this.store.findAll('post');
 
     // To get more we can query with `per_page`.
-    return this.get('store').query('post', {per_page: 99});
+    return this.get('store').query('wordpress/post', {per_page: 99});
   }
 });

--- a/tests/dummy/app/routes/posts/post.js
+++ b/tests/dummy/app/routes/posts/post.js
@@ -6,7 +6,7 @@ export default Ember.Route.extend({
     // return this.store.findRecord('post', params.id);
 
     // Support for slugs.
-    return this.store.query('post', {
+    return this.store.query('wordpress/post', {
       slug: params.post_slug
     }).then(models => models.get('firstObject'));
   }

--- a/tests/dummy/app/templates/components/article-item.hbs
+++ b/tests/dummy/app/templates/components/article-item.hbs
@@ -5,6 +5,8 @@
 	<time>date: {{article.date}}</time>
 </p>
 
+<img src="{{article.wp:featuredmedia.media_details.sizes.thumbnail.source_url}}">
+
 {{{article.content}}}
 
 <h3>Categories</h3>
@@ -21,6 +23,23 @@
 	{{/each}}
 </ul>
 
-
-
 {{outlet}}
+
+{{#if article.commentsAreOpen}}
+  <h3>Comments</h3>
+  {{#each article.replies as |comment|}}
+    <img src="{{comment.author_avatar_url_96}}">
+    <p>author name: {{comment.author_name}}</p>
+    <div>
+      <span>date: {{comment.date}}</span>
+    </div>
+    <p>
+      {{#if comment.isHolding}}
+        <em>Comment is holding.</em>
+      {{/if}}
+      {{#if comment.isApproved}}
+        {{{comment.content}}}
+      {{/if}}
+    </p>
+  {{/each}}
+{{/if}}

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,0 +1,37 @@
+import config from 'ember-get-config';
+
+export default function () {
+  this.urlPrefix = config.wordpressHost;
+  this.namespace = '/wp-json/wp/v2';
+
+  this.get('/posts', ({posts}, request) => {
+    return filterRecordsByRequest(posts, request);
+  });
+
+  this.get('/pages', ({pages}, request) => {
+    return filterRecordsByRequest(pages, request);
+  });
+
+  this.get('/media', ({attachments}, request) => {
+    return filterRecordsByRequest(attachments, request);
+  });
+
+  this.get('/tags', ({tags}, request) => {
+    return filterRecordsByRequest(tags, request);
+  });
+
+  this.get('/categories', ({tags}, request) => {
+    return filterRecordsByRequest(tags, request);
+  });
+
+  this.get('/tags/:id');
+  this.get('/categories/:id');
+
+  const filterRecordsByRequest = function (records, request) {
+    const per_page = request.queryParams.per_page ? request.queryParams.per_page : 10;
+    const page = request.queryParams.page ? request.queryParams.page : 1;
+    let where_params = {};
+    if (request.queryParams.slug) where_params.slug = request.queryParams.slug;
+    return records.where(where_params).slice((per_page * page) - per_page, per_page * page);
+  }
+}

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -26,6 +26,8 @@ export default function () {
 
   this.get('/tags/:id');
   this.get('/categories/:id');
+  this.get('/attachments/:id');
+  this.get('/comments/:id');
 
   const filterRecordsByRequest = function (records, request) {
     const per_page = request.queryParams.per_page ? request.queryParams.per_page : 10;

--- a/tests/dummy/mirage/factories/attachment.js
+++ b/tests/dummy/mirage/factories/attachment.js
@@ -1,0 +1,25 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  media_details() {
+    return {
+      sizes: {
+        thumbnail: {
+          source_url: faker.image.imageUrl()
+        },
+        medium: {
+          source_url: faker.image.imageUrl()
+        },
+        medium_large: {
+          source_url: faker.image.imageUrl()
+        },
+        large: {
+          source_url: faker.image.imageUrl()
+        },
+        full: {
+          source_url: faker.image.imageUrl()
+        }
+      }
+    }
+  }
+});

--- a/tests/dummy/mirage/factories/category.js
+++ b/tests/dummy/mirage/factories/category.js
@@ -1,0 +1,3 @@
+import TagFactory from './tag';
+
+export default TagFactory;

--- a/tests/dummy/mirage/factories/comment.js
+++ b/tests/dummy/mirage/factories/comment.js
@@ -1,0 +1,30 @@
+import {Factory, faker, association} from 'ember-cli-mirage';
+
+export default Factory.extend({
+
+  author_avatar_urls() {
+    return {
+      24: faker.image.avatar(),
+      48: faker.image.avatar(),
+      96: faker.image.avatar(),
+    }
+  },
+
+  author_name() {
+    return faker.name.firstName() + ' ' + faker.name.lastName();
+  },
+
+  content() {
+    return {
+      rendered: faker.lorem.text()
+    }
+  },
+
+  date() {
+    return new Date(faker.date.past());
+  },
+
+  post: association(),
+
+  status: 'approved'
+});

--- a/tests/dummy/mirage/factories/page.js
+++ b/tests/dummy/mirage/factories/page.js
@@ -1,0 +1,3 @@
+import PostFactory from './post';
+
+export default PostFactory

--- a/tests/dummy/mirage/factories/post.js
+++ b/tests/dummy/mirage/factories/post.js
@@ -1,0 +1,50 @@
+import { Factory, faker, association, trait } from 'ember-cli-mirage';
+
+export default Factory.extend({
+
+  title() {
+    return {
+      rendered: faker.lorem.sentence()
+    }
+  },
+
+  excerpt() {
+    return {
+      rendered: faker.lorem.text()
+    }
+  },
+
+  content() {
+    return {
+      rendered: faker.lorem.text()
+    }
+  },
+
+  date() {
+    return new Date(faker.date.past());
+  },
+
+  'wp:featuredmedia': association(),
+
+  afterCreate(post) {
+    post.update({
+      slug: faker.helpers.slugify(post.title.rendered)
+    });
+  },
+
+  withTags: trait({
+    afterCreate(post, server) {
+      post.update({
+        tags: server.createList('tag', 4)
+      });
+    }
+  }),
+
+  withCategories: trait({
+    afterCreate(post, server) {
+      post.update({
+        categories: server.createList('category', 4)
+      });
+    }
+  })
+});

--- a/tests/dummy/mirage/factories/post.js
+++ b/tests/dummy/mirage/factories/post.js
@@ -46,5 +46,12 @@ export default Factory.extend({
         categories: server.createList('category', 4)
       });
     }
+  }),
+
+  withReplies: trait({
+    afterCreate(post, server) {
+      post.update({comment_status: 'open'});
+      server.createList('comment', 5, {post: post});
+    }
   })
 });

--- a/tests/dummy/mirage/factories/tag.js
+++ b/tests/dummy/mirage/factories/tag.js
@@ -1,0 +1,14 @@
+import { Factory, faker } from 'ember-cli-mirage';
+
+export default Factory.extend({
+
+  name() {
+    return faker.lorem.word();
+  },
+
+  afterCreate(tag) {
+    tag.update({
+      slug: faker.helpers.slugify(tag.name)
+    });
+  },
+});

--- a/tests/dummy/mirage/models/attachment.js
+++ b/tests/dummy/mirage/models/attachment.js
@@ -1,0 +1,3 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model;

--- a/tests/dummy/mirage/models/category.js
+++ b/tests/dummy/mirage/models/category.js
@@ -1,0 +1,3 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model

--- a/tests/dummy/mirage/models/comment.js
+++ b/tests/dummy/mirage/models/comment.js
@@ -1,0 +1,5 @@
+import { Model, belongsTo } from 'ember-cli-mirage';
+
+export default Model.extend({
+  post: belongsTo('post', { inverse: 'replies' }),
+});

--- a/tests/dummy/mirage/models/page.js
+++ b/tests/dummy/mirage/models/page.js
@@ -1,0 +1,3 @@
+import PostModel from './post';
+
+export default PostModel

--- a/tests/dummy/mirage/models/post.js
+++ b/tests/dummy/mirage/models/post.js
@@ -4,4 +4,5 @@ export default Model.extend({
   'wp:featuredmedia': belongsTo('attachment'),
   tags: hasMany('tag'),
   categories: hasMany('category'),
+  replies: hasMany('comment', { inverse: 'post' })
 });

--- a/tests/dummy/mirage/models/post.js
+++ b/tests/dummy/mirage/models/post.js
@@ -1,0 +1,7 @@
+import { Model, belongsTo, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  'wp:featuredmedia': belongsTo('attachment'),
+  tags: hasMany('tag'),
+  categories: hasMany('category'),
+});

--- a/tests/dummy/mirage/models/tag.js
+++ b/tests/dummy/mirage/models/tag.js
@@ -1,0 +1,3 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model

--- a/tests/dummy/mirage/scenarios/default.js
+++ b/tests/dummy/mirage/scenarios/default.js
@@ -1,0 +1,4 @@
+export default function (server) {
+  server.createList('post', 10, 'withTags', 'withCategories');
+  server.create('page', {title: {rendered: 'about'}}, 'withTags', 'withCategories');
+}

--- a/tests/dummy/mirage/scenarios/default.js
+++ b/tests/dummy/mirage/scenarios/default.js
@@ -1,4 +1,4 @@
 export default function (server) {
-  server.createList('post', 10, 'withTags', 'withCategories');
+  server.createList('post', 10, 'withTags', 'withCategories', 'withReplies');
   server.create('page', {title: {rendered: 'about'}}, 'withTags', 'withCategories');
 }

--- a/tests/dummy/mirage/serializers/application.js
+++ b/tests/dummy/mirage/serializers/application.js
@@ -1,0 +1,17 @@
+import { RestSerializer } from 'ember-cli-mirage';
+
+export default RestSerializer.extend({
+  serialize(object, request) {
+    let json = RestSerializer.prototype.serialize.call(this, object, request);
+    return json[Object.keys(json)[0]];
+  },
+
+  keyForForeignKey(relationshipName) {
+    if (relationshipName === 'wp:featuredmedia') return relationshipName;
+    return RestSerializer.prototype.keyForForeignKey.apply(this, arguments);
+  },
+
+  keyForAttribute(attr){
+    return attr;
+  }
+});

--- a/tests/dummy/mirage/serializers/post.js
+++ b/tests/dummy/mirage/serializers/post.js
@@ -2,6 +2,6 @@ import ApplicationSerializer from './application';
 
 export default ApplicationSerializer.extend({
   include(){
-    return ['categories', 'tags', 'wp:featuredmedia']
+    return ['categories', 'tags', 'wp:featuredmedia', 'replies']
   }
 });

--- a/tests/dummy/mirage/serializers/post.js
+++ b/tests/dummy/mirage/serializers/post.js
@@ -1,0 +1,7 @@
+import ApplicationSerializer from './application';
+
+export default ApplicationSerializer.extend({
+  include(){
+    return ['categories', 'tags', 'wp:featuredmedia']
+  }
+});

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -2,4 +2,7 @@ import { run } from '@ember/runloop';
 
 export default function destroyApp(application) {
   run(application, 'destroy');
+  if (window.server) {
+    window.server.shutdown();
+  }
 }

--- a/tests/unit/models/wordpress/post-test.js
+++ b/tests/unit/models/wordpress/post-test.js
@@ -1,8 +1,14 @@
 import { moduleForModel, test } from 'ember-qunit';
 
-moduleForModel('post', 'Unit | Model | post', {
+moduleForModel('wordpress/post', 'Unit | Model | wordpress/post', {
   // Specify the other units that are required for this test.
-  needs: ['model:category', 'model:tag']
+  needs: [
+    'model:wordpress/category',
+    'model:wordpress/tag',
+    'model:wordpress/user',
+    'model:wordpress/comment',
+    'model:wordpress/attachment'
+  ]
 });
 
 test('it exists', function(assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -20,6 +20,10 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
+abab@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.0.tgz#aba0ab4c5eee2d4c79d3487d85450fb2376ebb0f"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -38,11 +42,22 @@ accepts@~1.3.4, accepts@~1.3.5:
     mime-types "~2.1.18"
     negotiator "0.6.1"
 
+acorn-globals@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.3.0.tgz#e3b6f8da3c1552a95ae627571f7dd6923bb54103"
+  dependencies:
+    acorn "^6.0.1"
+    acorn-walk "^6.0.1"
+
 acorn-jsx@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-3.0.1.tgz#afdf9488fb1ecefc8348f6fb22f464e32a58b36b"
   dependencies:
     acorn "^3.0.4"
+
+acorn-walk@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.1.0.tgz#c957f4a1460da46af4a0388ce28b4c99355b0cbc"
 
 acorn@^3.0.4:
   version "3.3.0"
@@ -51,6 +66,14 @@ acorn@^3.0.4:
 acorn@^5.5.0:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.5.3.tgz#f473dd47e0277a08e28e9bec5aeeb04751f0b8c9"
+
+acorn@^5.5.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+
+acorn@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.2.tgz#6a459041c320ab17592c6317abbfdf4bbaa98ca4"
 
 after@0.8.1:
   version "0.8.1"
@@ -277,6 +300,10 @@ async-each@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
 
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+
 async-promise-queue@^1.0.3, async-promise-queue@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/async-promise-queue/-/async-promise-queue-1.0.4.tgz#308baafbc74aff66a0bb6e7f4a18d4fe8434440c"
@@ -310,9 +337,17 @@ aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
+aws-sign2@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
+
 aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
+
+aws4@^1.8.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -1123,7 +1158,7 @@ broccoli-funnel-reducer@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel-reducer/-/broccoli-funnel-reducer-1.0.0.tgz#11365b2a785aec9b17972a36df87eef24c5cc0ea"
 
-broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
+broccoli-funnel@^1.0.0, broccoli-funnel@^1.0.1, broccoli-funnel@^1.0.2, broccoli-funnel@^1.1.0, broccoli-funnel@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/broccoli-funnel/-/broccoli-funnel-1.2.0.tgz#cddc3afc5ff1685a8023488fff74ce6fb5a51296"
   dependencies:
@@ -1186,7 +1221,7 @@ broccoli-lint-eslint@^4.2.1:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -1216,6 +1251,24 @@ broccoli-middleware@^1.0.0:
 broccoli-persistent-filter@^1.0.3, broccoli-persistent-filter@^1.1.6, broccoli-persistent-filter@^1.4.0, broccoli-persistent-filter@^1.4.3:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.3.tgz#3511bc52fc53740cda51621f58a28152d9911bc1"
+  dependencies:
+    async-disk-cache "^1.2.1"
+    async-promise-queue "^1.0.3"
+    broccoli-plugin "^1.0.0"
+    fs-tree-diff "^0.5.2"
+    hash-for-dep "^1.0.2"
+    heimdalljs "^0.2.1"
+    heimdalljs-logger "^0.1.7"
+    mkdirp "^0.5.1"
+    promise-map-series "^0.2.1"
+    rimraf "^2.6.1"
+    rsvp "^3.0.18"
+    symlink-or-copy "^1.0.1"
+    walk-sync "^0.3.1"
+
+broccoli-persistent-filter@^1.1.5:
+  version "1.4.6"
+  resolved "https://registry.yarnpkg.com/broccoli-persistent-filter/-/broccoli-persistent-filter-1.4.6.tgz#80762d19000880a77da33c34373299c0f6a3e615"
   dependencies:
     async-disk-cache "^1.2.1"
     async-promise-queue "^1.0.3"
@@ -1304,6 +1357,32 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
+broccoli-stew@^1.5.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.6.0.tgz#01f6d92806ed6679ddbe48d405066a0e164dfbef"
+  dependencies:
+    broccoli-debug "^0.6.1"
+    broccoli-funnel "^2.0.0"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-persistent-filter "^1.1.6"
+    broccoli-plugin "^1.3.0"
+    chalk "^2.4.1"
+    debug "^3.1.0"
+    ensure-posix-path "^1.0.1"
+    fs-extra "^5.0.0"
+    minimatch "^3.0.4"
+    resolve "^1.8.1"
+    rsvp "^4.8.3"
+    symlink-or-copy "^1.2.0"
+    walk-sync "^0.3.0"
+
+broccoli-string-replace@^0.1.1, broccoli-string-replace@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/broccoli-string-replace/-/broccoli-string-replace-0.1.2.tgz#1ed92f85680af8d503023925e754e4e33676b91f"
+  dependencies:
+    broccoli-persistent-filter "^1.1.5"
+    minimatch "^3.0.3"
+
 broccoli-uglify-sourcemap@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.1.1.tgz#33005537e18a322a181a5aea3e46d145b3355630"
@@ -1320,12 +1399,22 @@ broccoli-uglify-sourcemap@^2.0.1:
     walk-sync "^0.3.2"
     workerpool "^2.3.0"
 
+broccoli-unwatched-tree@^0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/broccoli-unwatched-tree/-/broccoli-unwatched-tree-0.1.3.tgz#ab0fb820f613845bf67a803baad820f68b1e3aae"
+  dependencies:
+    broccoli-source "^1.1.0"
+
 broccoli-writer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-writer/-/broccoli-writer-0.1.1.tgz#d4d71aa8f2afbc67a3866b91a2da79084b96ab2d"
   dependencies:
     quick-temp "^0.1.0"
     rsvp "^3.0.6"
+
+browser-process-hrtime@^0.1.2:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz#616f00faef1df7ec1b5bf9cfe2bdc3170f26c7b4"
 
 browserslist@^2.1.2:
   version "2.11.3"
@@ -1466,6 +1555,14 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
+  dependencies:
+    ansi-styles "^3.2.1"
+    escape-string-regexp "^1.0.5"
+    supports-color "^5.3.0"
+
+chalk@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -1615,6 +1712,12 @@ colors@^1.1.2:
 combined-stream@^1.0.5, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@^1.0.6, combined-stream@~1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -1789,6 +1892,16 @@ crypto-random-string@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
 
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.4.tgz#8cd52e8a3acfd68d3aed38ee0a640177d2f9d797"
+
+cssstyle@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-1.1.1.tgz#18b038a9c44d65f7a8e428a653b9f6fe42faf5fb"
+  dependencies:
+    cssom "0.3.x"
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -1810,6 +1923,14 @@ dashdash@^1.12.0:
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+data-urls@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-1.1.0.tgz#15ee0582baa5e22bb59c77140da8f9c76963bbfe"
+  dependencies:
+    abab "^2.0.0"
+    whatwg-mimetype "^2.2.0"
+    whatwg-url "^7.0.0"
 
 debug@2.2.0:
   version "2.2.0"
@@ -1937,6 +2058,12 @@ doctrine@^2.1.0:
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
   dependencies:
     esutils "^2.0.2"
+
+domexception@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-1.0.1.tgz#937442644ca6a31261ef36e3ec677fe805582c90"
+  dependencies:
+    webidl-conversions "^4.0.2"
 
 dot-prop@^4.1.0:
   version "4.2.0"
@@ -2078,6 +2205,37 @@ ember-cli-lodash-subset@^1.0.7:
 ember-cli-lodash-subset@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
+
+ember-cli-mirage@^0.4.9:
+  version "0.4.9"
+  resolved "https://registry.yarnpkg.com/ember-cli-mirage/-/ember-cli-mirage-0.4.9.tgz#c49bfe875d0cdf88c85a6ee55103d1980175b914"
+  dependencies:
+    broccoli-funnel "^1.0.2"
+    broccoli-merge-trees "^1.1.0"
+    broccoli-stew "^1.5.0"
+    broccoli-string-replace "^0.1.2"
+    chalk "^1.1.1"
+    ember-cli-babel "^6.8.2"
+    ember-cli-node-assets "^0.1.4"
+    ember-get-config "^0.2.2"
+    ember-inflector "^2.0.0"
+    ember-lodash "^4.17.3"
+    fake-xml-http-request "^1.4.0"
+    faker "^3.0.0"
+    jsdom "^11.12.0"
+    pretender "^1.6.1"
+    route-recognizer "^0.2.3"
+
+ember-cli-node-assets@^0.1.4:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ember-cli-node-assets/-/ember-cli-node-assets-0.1.6.tgz#6488a2949048c801ad6d9e33753c7bce32fc1146"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.1.1"
+    broccoli-unwatched-tree "^0.1.1"
+    debug "^2.2.0"
+    lodash "^4.5.1"
+    resolve "^1.1.7"
 
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
@@ -2300,7 +2458,7 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
-ember-get-config@^0.2.1:
+ember-get-config@^0.2.1, ember-get-config@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/ember-get-config/-/ember-get-config-0.2.4.tgz#118492a2a03d73e46004ed777928942021fe1ecd"
   dependencies:
@@ -2318,6 +2476,17 @@ ember-load-initializers@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-1.0.0.tgz#4919eaf06f6dfeca7e134633d8c05a6c9921e6e7"
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
+
+ember-lodash@^4.17.3:
+  version "4.18.0"
+  resolved "https://registry.yarnpkg.com/ember-lodash/-/ember-lodash-4.18.0.tgz#45de700d6a4f68f1cd62888d90b50aa6477b9a83"
+  dependencies:
+    broccoli-debug "^0.6.1"
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-string-replace "^0.1.1"
+    ember-cli-babel "^6.10.0"
+    lodash-es "^4.17.4"
 
 ember-qunit@^3.3.2:
   version "3.3.2"
@@ -2532,6 +2701,17 @@ escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+escodegen@^1.9.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.11.0.tgz#b27a9389481d5bfd5bec76f7bb1eb3f8f4556589"
+  dependencies:
+    esprima "^3.1.3"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-scope@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
@@ -2593,6 +2773,10 @@ espree@^3.5.4:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
+esprima@^3.1.3, esprima@~3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
@@ -2600,10 +2784,6 @@ esprima@^4.0.0:
 esprima@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.0.0.tgz#53cf247acda77313e551c3aa2e73342d3fb4f7d9"
-
-esprima@~3.1.0:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esquery@^1.0.0:
   version "1.0.0"
@@ -2617,7 +2797,7 @@ esrecurse@^4.1.0:
   dependencies:
     estraverse "^4.1.0"
 
-estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1:
+estraverse@^4.0.0, estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.2.0.tgz#0dee3fed31fcd469618ce7342099fc1afa0bdb13"
 
@@ -2778,6 +2958,10 @@ extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
+extend@~3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
+
 external-editor@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-1.1.1.tgz#12d7b0db850f7ff7e7081baf4005700060c4600b"
@@ -2820,6 +3004,14 @@ extsprintf@1.3.0:
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
+
+fake-xml-http-request@^1.4.0, fake-xml-http-request@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/fake-xml-http-request/-/fake-xml-http-request-1.6.0.tgz#bd0ac79ae3e2660098282048a12c730a6f64d550"
+
+faker@^3.0.0:
+  version "3.1.0"
+  resolved "http://registry.npmjs.org/faker/-/faker-3.1.0.tgz#0f908faf4e6ec02524e54a57e432c5c013e08c9f"
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
@@ -2992,6 +3184,14 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
+form-data@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 forwarded@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
@@ -3057,6 +3257,14 @@ fs-extra@^2.0.0:
 fs-extra@^4.0.0, fs-extra@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^4.0.0"
@@ -3266,12 +3474,23 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
+har-schema@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
+
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
+
+har-validator@~5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.0.tgz#44657f5688a22cfd4b72486e81b3a3fb11742c29"
+  dependencies:
+    ajv "^5.3.0"
+    har-schema "^2.0.0"
 
 has-ansi@^0.1.0:
   version "0.1.0"
@@ -3405,6 +3624,12 @@ hosted-git-info@^2.1.4, hosted-git-info@^2.1.5:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.6.0.tgz#23235b29ab230c576aab0d4f13fc046b0b038222"
 
+html-encoding-sniffer@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
+  dependencies:
+    whatwg-encoding "^1.0.1"
+
 http-errors@1.6.2, http-errors@~1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
@@ -3433,9 +3658,23 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+http-signature@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
+  dependencies:
+    assert-plus "^1.0.0"
+    jsprim "^1.2.2"
+    sshpk "^1.7.0"
+
 iconv-lite@0.4.19, iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
+
+iconv-lite@0.4.24:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 ignore@^3.3.3:
   version "3.3.7"
@@ -3803,6 +4042,37 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
+jsdom@^11.12.0:
+  version "11.12.0"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-11.12.0.tgz#1a80d40ddd378a1de59656e9e6dc5a3ba8657bc8"
+  dependencies:
+    abab "^2.0.0"
+    acorn "^5.5.3"
+    acorn-globals "^4.1.0"
+    array-equal "^1.0.0"
+    cssom ">= 0.3.2 < 0.4.0"
+    cssstyle "^1.0.0"
+    data-urls "^1.0.0"
+    domexception "^1.0.1"
+    escodegen "^1.9.1"
+    html-encoding-sniffer "^1.0.2"
+    left-pad "^1.3.0"
+    nwsapi "^2.0.7"
+    parse5 "4.0.0"
+    pn "^1.1.0"
+    request "^2.87.0"
+    request-promise-native "^1.0.5"
+    sax "^1.2.4"
+    symbol-tree "^3.2.2"
+    tough-cookie "^2.3.4"
+    w3c-hr-time "^1.0.1"
+    webidl-conversions "^4.0.2"
+    whatwg-encoding "^1.0.3"
+    whatwg-mimetype "^2.1.0"
+    whatwg-url "^6.4.1"
+    ws "^5.2.0"
+    xml-name-validator "^3.0.0"
+
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
@@ -3912,6 +4182,10 @@ leek@0.0.24:
     lodash.assign "^3.2.0"
     rsvp "^3.0.21"
 
+left-pad@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -3949,6 +4223,10 @@ locate-path@^2.0.0:
   dependencies:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
+
+lodash-es@^4.17.4:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
 
 lodash._baseassign@^3.0.0:
   version "3.2.0"
@@ -4213,6 +4491,10 @@ lodash.restparam@^3.0.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
 lodash.support@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/lodash.support/-/lodash.support-2.3.0.tgz#7eaf038af4f0d6aab776b44aa6dcfc80334c9bfd"
@@ -4268,6 +4550,10 @@ lodash.values@~2.3.0:
 lodash@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
+lodash@^4.13.1, lodash@^4.5.1:
+  version "4.17.11"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
 lodash@^4.14.0, lodash@^4.17.4, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.5"
@@ -4463,11 +4749,21 @@ micromatch@^3.0.4, micromatch@^3.1.4:
   version "1.33.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
 
+mime-db@~1.37.0:
+  version "1.37.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.37.0.tgz#0b6a0ce6fdbe9576e25f1f2d2fde8830dc0ad0d8"
+
 mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.11, mime-types@~2.1.18, mime-types@~2.1.7:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   dependencies:
     mime-db "~1.33.0"
+
+mime-types@~2.1.19:
+  version "2.1.21"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.21.tgz#28995aa1ecb770742fe6ae7e58f9181c744b3f96"
+  dependencies:
+    mime-db "~1.37.0"
 
 mime@1.4.1:
   version "1.4.1"
@@ -4477,7 +4773,7 @@ mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
@@ -4681,9 +4977,17 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
+nwsapi@^2.0.7:
+  version "2.0.9"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.9.tgz#77ac0cdfdcad52b6a1151a84e73254edc33ed016"
+
 oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
+
+oauth-sign@~0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
 object-assign@4.1.0:
   version "4.1.0"
@@ -4757,7 +5061,7 @@ optimist@^0.6.1:
     minimist "~0.0.1"
     wordwrap "~0.0.2"
 
-optionator@^0.8.2:
+optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.2.tgz#364c5e409d3f4d6301d6c0b4c05bba50180aeb64"
   dependencies:
@@ -4841,6 +5145,10 @@ parse-passwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
 
+parse5@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
+
 parsejson@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/parsejson/-/parsejson-0.0.3.tgz#ab7e3759f209ece99437973f7d0f1f64ae0e64ab"
@@ -4919,6 +5227,10 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -4941,6 +5253,10 @@ pluralize@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
+pn@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+
 portfinder@^1.0.7:
   version "1.0.13"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.13.tgz#bb32ecd87c27104ae6ee44b5a3ccbf0ebb1aede9"
@@ -4960,6 +5276,13 @@ prelude-ls@~1.1.2:
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+pretender@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/pretender/-/pretender-1.6.1.tgz#77d1e42ac8c6b298f5cd43534a87645df035db8c"
+  dependencies:
+    fake-xml-http-request "^1.6.0"
+    route-recognizer "^0.3.3"
 
 printf@^0.2.3:
   version "0.2.5"
@@ -5000,9 +5323,17 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+psl@^1.1.24:
+  version "1.1.29"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
+
+punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 qs@6.5.1, qs@^6.4.0:
   version "6.5.1"
@@ -5011,6 +5342,10 @@ qs@6.5.1, qs@^6.4.0:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
+
+qs@~6.5.2:
+  version "6.5.2"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 
 quick-temp@^0.1.0, quick-temp@^0.1.2, quick-temp@^0.1.3, quick-temp@^0.1.5, quick-temp@^0.1.8:
   version "0.1.8"
@@ -5208,6 +5543,20 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
+request-promise-core@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.1.tgz#3eee00b2c5aa83239cfb04c5700da36f81cd08b6"
+  dependencies:
+    lodash "^4.13.1"
+
+request-promise-native@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.5.tgz#5281770f68e0c9719e5163fd3fab482215f4fda5"
+  dependencies:
+    request-promise-core "1.1.1"
+    stealthy-require "^1.1.0"
+    tough-cookie ">=2.3.3"
+
 request@2.81.0:
   version "2.81.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
@@ -5234,6 +5583,31 @@ request@2.81.0:
     tough-cookie "~2.3.0"
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
+
+request@^2.87.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 require-uncached@^1.0.3:
   version "1.0.3"
@@ -5280,6 +5654,12 @@ resolve@^1.1.6, resolve@^1.3.0, resolve@^1.3.3, resolve@^1.4.0, resolve@^1.5.0:
   dependencies:
     path-parse "^1.0.5"
 
+resolve@^1.1.7, resolve@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
+  dependencies:
+    path-parse "^1.0.5"
+
 restore-cursor@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
@@ -5320,6 +5700,14 @@ rollup@^0.41.4:
   dependencies:
     source-map-support "^0.4.0"
 
+route-recognizer@^0.2.3:
+  version "0.2.10"
+  resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.2.10.tgz#024b2283c2e68d13a7c7f5173a5924645e8902df"
+
+route-recognizer@^0.3.3:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/route-recognizer/-/route-recognizer-0.3.4.tgz#39ab1ffbce1c59e6d2bdca416f0932611e4f3ca3"
+
 rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.6, rsvp@^3.1.0, rsvp@^3.2.1, rsvp@^3.3.3, rsvp@^3.5.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
@@ -5327,6 +5715,10 @@ rsvp@^3.0.14, rsvp@^3.0.16, rsvp@^3.0.17, rsvp@^3.0.18, rsvp@^3.0.21, rsvp@^3.0.
 rsvp@^4.6.1, rsvp@^4.7.0:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.2.tgz#9d5647108735784eb13418cdddb56f75b919d722"
+
+rsvp@^4.8.3:
+  version "4.8.4"
+  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.4.tgz#b50e6b34583f3dd89329a2f23a8a2be072845911"
 
 rsvp@~3.0.6:
   version "3.0.21"
@@ -5360,6 +5752,10 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
+safe-buffer@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+
 safe-json-parse@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/safe-json-parse/-/safe-json-parse-1.0.1.tgz#3e76723e38dfdda13c9b1d29a1e07ffee4b30b57"
@@ -5369,6 +5765,10 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
   dependencies:
     ret "~0.1.10"
+
+"safer-buffer@>= 2.1.2 < 3":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
 
 sane@^1.6.0:
   version "1.7.0"
@@ -5395,6 +5795,10 @@ sane@^2.4.1:
     watch "~0.18.0"
   optionalDependencies:
     fsevents "^1.1.1"
+
+sax@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
 "semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.1.1, semver@^5.3.0, semver@^5.4.1:
   version "5.5.0"
@@ -5711,6 +6115,10 @@ static-extend@^0.1.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"
 
+stealthy-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
+
 string-template@~0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/string-template/-/string-template-0.2.1.tgz#42932e598a352d01fc22ec3367d9d84eec6c9add"
@@ -5810,7 +6218,11 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8:
+symbol-tree@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
+
+symlink-or-copy@^1.0.0, symlink-or-copy@^1.0.1, symlink-or-copy@^1.1.8, symlink-or-copy@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symlink-or-copy/-/symlink-or-copy-1.2.0.tgz#5d49108e2ab824a34069b68974486c290020b393"
 
@@ -5968,11 +6380,24 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
 tough-cookie@~2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:
     punycode "^1.4.1"
+
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
 
 tree-sync@^1.2.1, tree-sync@^1.2.2:
   version "1.2.2"
@@ -6138,6 +6563,10 @@ uuid@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
 
+uuid@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
+
 validate-npm-package-license@^3.0.1:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz#81643bcbef1bdfecd4623793dc4648948ba98338"
@@ -6162,6 +6591,12 @@ verror@1.10.0:
     assert-plus "^1.0.0"
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
+
+w3c-hr-time@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz#82ac2bff63d950ea9e3189a58a65625fedf19045"
+  dependencies:
+    browser-process-hrtime "^0.1.2"
 
 walk-sync@0.3.2, walk-sync@^0.3.0, walk-sync@^0.3.1, walk-sync@^0.3.2:
   version "0.3.2"
@@ -6200,6 +6635,10 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
+
 websocket-driver@>=0.5.1:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"
@@ -6210,6 +6649,32 @@ websocket-driver@>=0.5.1:
 websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
+
+whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz#5abacf777c32166a51d085d6b4f3e7d27113ddb0"
+  dependencies:
+    iconv-lite "0.4.24"
+
+whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz#a3d58ef10b76009b042d03e25591ece89b88d171"
+
+whatwg-url@^6.4.1:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
+
+whatwg-url@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-7.0.0.tgz#fde926fa54a599f3adf82dff25a9f7be02dc6edd"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 which@^1.2.12, which@^1.2.14, which@^1.2.9, which@^1.3.0:
   version "1.3.0"
@@ -6270,6 +6735,12 @@ ws@1.1.1:
     options ">=0.0.5"
     ultron "1.0.x"
 
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  dependencies:
+    async-limiter "~1.0.0"
+
 wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
@@ -6277,6 +6748,10 @@ wtf-8@1.0.0:
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
+
+xml-name-validator@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
 
 xmldom@^0.1.19:
   version "0.1.27"


### PR DESCRIPTION
I decided to use the addon in our ember app. This ember app is pretty large and complex, so i needed to add the namespaces in order to prevent model-name confusion. 
Furthermore i added a few more models, like `user`, `attachment` and `comment`, so you are able to load e.g. the posts comments. 
Overall i refactored a few things, like the `rendered` object key handling. I added an Ember-Transform to handle this in the model class. 

i hope these changes are useful to some other people.