### PR TITLE
Make use of dotenv vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ testem.log
 .node_modules.ember-try/
 bower.json.ember-try
 package.json.ember-try
+package-lock.json
 
 # JetBrain IDE files
 /.idea

--- a/addon/adapters/wordpress.js
+++ b/addon/adapters/wordpress.js
@@ -1,13 +1,59 @@
 import DS from 'ember-data';
 import config from 'ember-get-config';
 import getHeader from '../utils/get-header';
+import {
+	computed
+} from '@ember/object';
+import {
+	getOwner
+} from '@ember/application';
 
 // The WP API requires a rest adapter.
 export default DS.RESTAdapter.extend({
-  // Where your Wordpress installation is.
-	host: config.emberWordpress.host,
 
-  // Whether to send many requests or to one-big request.
+	/**
+	 * Load this adapter after  'ember-cli-fastboot-dotenv' has loaded.
+	 */
+	after: 'ember-cli-fastboot-dotenv',
+
+	/**
+	 * --- was "host: config.emberWordpress.host " but has been modified to
+	 * use ember-cli-fastboot-dotenv for fetching the wordpress host from the
+	 * .env file (or any set environment variable)
+	 */
+	host: computed(function() {
+		if (this.get('WORDPRESS_HOST')) {
+			// Wordpress Hostb is already fetched, just return it!
+			return this.get('WORDPRESS_HOST');
+		}
+
+		// host was not fetched yet, let’s ask dotenv service for the variable...
+		let dotenv = getOwner(this).lookup('service:dotenv');
+
+		if (dotenv) {
+			// dotenv was found and loaded, let’s fetch the variable
+			let {
+				WORDPRESS_HOST
+			} = dotenv.getProperties('WORDPRESS_HOST');
+
+			if (WORDPRESS_HOST) {
+				// we could find a WORDPRESS_HOST variable, let’s store it.
+				this.set('WORDPRESS_HOST', WORDPRESS_HOST);
+
+				// ...and return it.
+				return this.get('WORDPRESS_HOST');
+			}
+		}
+
+		// either dotenv was not found or it did not contain any WORDPRESS_HOST variable,
+		// let’s get the host from the config...
+		this.set('WORDPRESS_HOST', config.emberWordpress.host);
+
+		// ...and return it.
+		return this.get('WORDPRESS_HOST');
+	}),
+
+	// Whether to send many requests or to one-big request.
 	coalesceFindRequests: config.emberWordpress.coalesceFindRequests || false,
 
 	// This is the default namespace for WP API v2.
@@ -26,8 +72,8 @@ export default DS.RESTAdapter.extend({
 		return this._super(status, headers, payload, requestData);
 	},
 
-  pathForType: function(modelName) {
-    modelName = modelName.replace('wordpress/', '');
-    return this._super(modelName);
-  }
+	pathForType: function(modelName) {
+		modelName = modelName.replace('wordpress/', '');
+		return this._super(modelName);
+	}
 });


### PR DESCRIPTION
The changes replace the `host` variable by a computed value that tries to use a value from `ember-cli-fastboot-dotenv` - it falls back to the original value (`config.emberWordpress.host`) if there is no dotenv service or if it does not comtain a value.