### PR TITLE
Fix coalescing find requests

### DIFF
--- a/addon/adapters/wordpress.js
+++ b/addon/adapters/wordpress.js
@@ -29,5 +29,10 @@ export default DS.RESTAdapter.extend({
   pathForType: function(modelName) {
     modelName = modelName.replace('wordpress/', '');
     return this._super(modelName);
+  },
+
+  findMany(store, type, ids, snapshots) {
+    let url = this.buildURL(type.modelName, ids, snapshots, 'findMany');
+    return this.ajax(url, 'GET', { data: { include: ids } });
   }
 });


### PR DESCRIPTION
Currently, coalescing find requests will not actually do what you'd expect. The API call does not fail, but it will not actually fetch the given IDs.

This PR should fix the issue - I tried it in our app.

Fixes #55 