### PR TITLE
Bump ember-cli-babel from 7.26.3 to 7.26.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Note: the `wordpress/post` and `wordpress/page` models are identical and so are 
 
 ```js
 // app/models/recipe.js
-import Model, { attr } from '@ember-data/model';
 import PostModel from 'ember-wordpress/models/post';
+import { attr } from '@ember-data/model';
 export default class RecipeModel extends PostModel {
   @attr() ingredients;
 }

--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Note: the `wordpress/post` and `wordpress/page` models are identical and so are 
 
 ```js
 // app/models/recipe.js
-import DS from 'ember-data';
+import Model, { attr } from '@ember-data/model';
 import PostModel from 'ember-wordpress/models/post';
-export default PostModel.extend({
-  ingredients: DS.attr()
-});
+export default class RecipeModel extends PostModel {
+  @attr() ingredients;
+}
 ```
 
 If you're using the ACF plugin your custom fields will be at `model.get('acf.myCustomField')`.

--- a/addon/models/comment.js
+++ b/addon/models/comment.js
@@ -6,7 +6,7 @@ export default class CommentModel extends BaseModel {
   @attr('string') author_name;
   @attr('string') author_email;
   @attr('string') author_url;
-  @attr('rendered') content;
+  @attr('rendered') body;
   @attr('string') link;
   @attr('string') status;
   @belongsTo('wordpress/post') post;

--- a/addon/models/post.js
+++ b/addon/models/post.js
@@ -3,7 +3,7 @@ import BaseModel from './base';
 
 export default class PostModel extends BaseModel {
   @attr('string') comment_status;
-  @attr('rendered') content;
+  @attr('rendered') body;
   @attr('rendered') excerpt;
   @attr('string') link;
   @attr('number') menu_order;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "deploy": "npm run build; mv dist/index.html dist/200.html; surge dist https://ember-wordpress.surge.sh"
   },
   "dependencies": {
-    "ember-cli-babel": "^7.26.3",
+    "ember-cli-babel": "^7.26.6",
     "ember-cli-htmlbars": "^5.7.1"
   },
   "devDependencies": {

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -49,7 +49,7 @@ module('Acceptance | application', function (hooks) {
         firstPost['wp:featuredmedia'].media_details.sizes.thumbnail.source_url
       );
 
-    assert.dom('[data-test-post-content]').hasText(firstPost.content.rendered);
+    assert.dom('[data-test-post-body]').hasText(firstPost.body.rendered);
 
     assert
       .dom('[data-test-post-category]')
@@ -112,7 +112,7 @@ module('Acceptance | application', function (hooks) {
         page['wp:featuredmedia'].media_details.sizes.thumbnail.source_url
       );
 
-    assert.dom('[data-test-post-content]').hasText(page.content.rendered);
+    assert.dom('[data-test-post-body]').hasText(page.body.rendered);
 
     assert
       .dom('[data-test-post-category]')

--- a/tests/dummy/app/templates/components/article-item.hbs
+++ b/tests/dummy/app/templates/components/article-item.hbs
@@ -23,8 +23,8 @@
   data-test-post-image
 />
 
-<div data-test-post-content>
-  {{@article.content}}
+<div data-test-post-body>
+  {{@article.body}}
 </div>
 
 <h3>
@@ -79,7 +79,7 @@
           </em>
         {{/if}}
         {{#if comment.isApproved}}
-          {{comment.content}}
+          {{comment.body}}
         {{/if}}
       </p>
     </div>

--- a/tests/dummy/mirage/factories/comment.js
+++ b/tests/dummy/mirage/factories/comment.js
@@ -14,7 +14,7 @@ export default Factory.extend({
     return faker.name.firstName() + ' ' + faker.name.lastName();
   },
 
-  content() {
+  body() {
     return {
       rendered: faker.lorem.text(),
     };

--- a/tests/dummy/mirage/factories/post.js
+++ b/tests/dummy/mirage/factories/post.js
@@ -14,7 +14,7 @@ export default Factory.extend({
     };
   },
 
-  content() {
+  body() {
     return {
       rendered: faker.lorem.text(),
     };


### PR DESCRIPTION
- Needed in order to remove deprecation warning in ember-cli@3.27.0
- Change `PostModel` and `CommentModel` attributes from `content` to `body` #60 